### PR TITLE
Fix "warning: implicit declaration of function ‘time’" by including time.h

### DIFF
--- a/kilo.c
+++ b/kilo.c
@@ -50,6 +50,7 @@
 #include <unistd.h>
 #include <stdarg.h>
 #include <fcntl.h>
+#include <time.h>
 
 /* Syntax highlight types */
 #define HL_NORMAL 0


### PR DESCRIPTION
Before (Linux):

```
$ make
cc -o kilo kilo.c -Wall -W -pedantic -std=c99
kilo.c: In function ‘editorRefreshScreen’:
kilo.c:953:5: warning: implicit declaration of function ‘time’ [-Wimplicit-function-declaration]
     if (msglen && time(NULL)-E.statusmsg_time < 5)
     ^
$
```

After:

```
$ make
cc -o kilo kilo.c -Wall -W -pedantic -std=c99
$
```