### PR TITLE
Fix "implicit declaration of function ‘time’" warning on Linux

### DIFF
--- a/kilo.c
+++ b/kilo.c
@@ -46,7 +46,7 @@
 #include <ctype.h>
 #include <sys/types.h>
 #include <sys/ioctl.h>
-#include <sys/time.h>
+#include <time.h>
 #include <unistd.h>
 #include <stdarg.h>
 #include <fcntl.h>


### PR DESCRIPTION
```
$ gcc --version
gcc (Ubuntu 4.8.4-2ubuntu1~14.04.3) 4.8.4
[...]

$ make
cc -o kilo kilo.c -Wall -W -pedantic -std=c99
kilo.c: In function ‘editorRefreshScreen’:
kilo.c:954:5: warning: implicit declaration of function ‘time’ [-Wimplicit-function-declaration]
     if (msglen && time(NULL)-E.statusmsg_time < 5)
     ^
```