### PR TITLE
Fix editorUpdateSyntax

### DIFF
--- a/kilo.c
+++ b/kilo.c
@@ -398,7 +398,7 @@ void editorUpdateSyntax(erow *row) {
         /* Handle // comments. */
         if (prev_sep && *p == scs[0] && *(p+1) == scs[1]) {
             /* From here to end is a comment */
-            memset(row->hl+i,HL_COMMENT,row->size-i);
+            memset(row->hl+i,HL_COMMENT,row->rsize-i);
             return;
         }
 


### PR DESCRIPTION
`\t\\` leads to a crash due to `memset` with negative inputs in editorUpdateSyntax. This commit fixed it.