### PR TITLE
Go to start/end of line

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ Keys:
     CTRL-S: Save
     CTRL-Q: Quit
     CTRL-F: Find string in file (ESC to exit search, arrows to navigate)
+    CTRL-U: Move up one line (alt: up arrow)
+    CTRL-D: Move down one line (alt: down arrow)
+    CTRL-R: Move right one character (alt: right arrow)
+    CTRL-L: Move left one character (alt: left arrow)
 
 Kilo does not depend on any library (not even curses). It uses fairly standard
 VT100 (and similar terminals) escape sequences. The project is in alpha

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 Kilo
-===
+====
 
 Kilo is a small text editor in less than 1K lines of code (counted with cloc).
 
@@ -24,3 +24,7 @@ style CLI.
 
 Kilo was written by Salvatore Sanfilippo aka antirez and is released
 under the BSD 2 clause license.
+
+Additions by matthewrsj
+
+**Forked from antirez/kilo**

--- a/TODO
+++ b/TODO
@@ -8,3 +8,4 @@ MAYBE
 
 * Send alternate screen sequences if TERM=xterm: "\033[?1049h" and "\033[?1049l"
 * Improve internals to be more understandable.
+* Add more CTRL commands such as up/down/right/left

--- a/kilo.c
+++ b/kilo.c
@@ -1202,6 +1202,7 @@ void editorProcessKeypress(int fd) {
             quit_times--;
             return;
         }
+        system("/usr/bin/clear");
         exit(0);
         break;
     case CTRL_S:        /* Ctrl-s */

--- a/kilo.c
+++ b/kilo.c
@@ -34,7 +34,7 @@
 
 #define KILO_VERSION "0.0.1"
 
-#define _BSD_SOURCE
+#define _DEFAULT_SOURCE
 #define _GNU_SOURCE
 
 #include <termios.h>
@@ -42,7 +42,7 @@
 #include <stdio.h>
 #include <errno.h>
 #include <string.h>
-#include <stdlib.h>
+#include <time.h>
 #include <ctype.h>
 #include <sys/types.h>
 #include <sys/ioctl.h>

--- a/kilo.c
+++ b/kilo.c
@@ -166,7 +166,18 @@ char *C_HL_keywords[] = {
         "struct","union","typedef","static","enum","class",
         /* C types */
         "int|","long|","double|","float|","char|","unsigned|","signed|",
-        "void|",NULL
+        "void|","uint32_t|","uint64_t|",NULL
+};
+
+/* python */
+char *PY_HL_extensions[] = {".py","python",NULL};
+char *PY_HL_keywords[] = {
+	"def","if","while","for","break","return","continue","else","elif",
+	"True","False","class",
+	/* Python types */
+	"int|","str|","unicode|","dict|","float|","repr|","long|","eval|",
+	"tuple|","list|","set|","frozenset|","chr|","unichr|","ord|","hex|",
+	"oct|","complex|",NULL
 };
 
 /* Here we define an array of syntax highlights by extensions, keywords,
@@ -177,6 +188,12 @@ struct editorSyntax HLDB[] = {
         C_HL_extensions,
         C_HL_keywords,
         "//","/*","*/",
+        HL_HIGHLIGHT_STRINGS | HL_HIGHLIGHT_NUMBERS
+    },
+    {
+        PY_HL_extensions,
+        PY_HL_keywords,
+        "#","\"\"\"", "\"\"\"",
         HL_HIGHLIGHT_STRINGS | HL_HIGHLIGHT_NUMBERS
     }
 };

--- a/kilo.c
+++ b/kilo.c
@@ -173,7 +173,10 @@ char *C_HL_keywords[] = {
 char *PY_HL_extensions[] = {".py","python",NULL};
 char *PY_HL_keywords[] = {
 	"def","if","while","for","break","return","continue","else","elif",
-	"True","False","class",
+	"True","False","class","and","as","assert","del","except","except:",
+	"finally","finally:", "from","global","import","in","is","lambda",
+	"nonlocal","not","or","pass","raise","return","try:","try","with",
+	"yeild",
 	/* Python types */
 	"int|","str|","unicode|","dict|","float|","repr|","long|","eval|",
 	"tuple|","list|","set|","frozenset|","chr|","unichr|","ord|","hex|",


### PR DESCRIPTION
Hi. Saw the issues on matthewsrj fork and figured I could implement it. New to this so I don't know who is actually getting this pull request.

Bindings are Ctrl-J to the beginning of the line and Ctrl-K to the end, ASCII control codes 10,11 respectively. The switch for movement is wonky, I threw it in before the direction keys.