### PR TITLE
Highlighting and movements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+CC := gcc
 all: kilo
 
 kilo: kilo.c

--- a/kilo.c
+++ b/kilo.c
@@ -168,9 +168,9 @@ char *C_HL_keywords[] = {
         /* A few C / C++ keywords */
         "auto","switch","if","while","for","break","continue","return","else",
         "struct","union","typedef","static","enum","class",
-    /* C preprocessor directives */
-    "#define|","#endif|","#error|","#ifdef|","#ifndef|","#if|",
-    "#include|","#undef|",
+        /* C preprocessor directives */
+        "#define|","#endif|","#error|","#ifdef|","#ifndef|","#if|",
+        "#include|","#undef|",
         /* C types */
         "int|","long|","double|","float|","char|","unsigned|","signed|",
         "void|",NULL
@@ -179,8 +179,8 @@ char *C_HL_keywords[] = {
 /* Python */
 char *PY_HL_extensions[] = {".py",".python",NULL};
 char *PY_HL_keywords[] = {
-    /* Normal Python reserved words "self" is not exactly a keyword,*/
-    /* but I prefer it. */
+        /* Normal Python reserved words "self" is not exactly a keyword,*/
+        /* but it almost is, so we'll highlight it. */
         "False","None","True","and","as","assert","break","class","continue",
         "def","del","elif","else","except","finally","for","from","global",
         "if","import","in","is","lambda","nonlocal","not","or","pass","raise",
@@ -588,7 +588,7 @@ void editorSelectSyntaxHighlight(char *filename) {
 void editorUpdateRow(erow *row) {
     int tabs = 0, nonprint = 0, j, idx;
 
-   /* Create a version of the row we can directly print on the screen,
+    /* Create a version of the row we can directly print on the screen,
      * respecting tabs, substituting non printable characters with '?'. */
     free(row->render);
     for (j = 0; j < row->size; j++)

--- a/kilo.c
+++ b/kilo.c
@@ -1207,7 +1207,7 @@ void editorMoveCursor(int key) {
         E.cx = 0;
         break;
     case END_KEY:
-		if (E.cy < E.numrows)
+        if (E.rowoff + E.cy < E.numrows) /* Prevent Seg Faults */
             E.cx = row->size;
         break;
     }

--- a/kilo.c
+++ b/kilo.c
@@ -72,6 +72,7 @@ struct editorSyntax {
     char **filematch;
     char **keywords;
     char singleline_comment_start[2];
+	char singleline_doc_comment_start[4];
     char multiline_comment_start[4];
     char multiline_comment_end[4];
     int flags;
@@ -197,13 +198,13 @@ struct editorSyntax HLDB[] = {
         /* C / C++ */
         C_HL_extensions,
         C_HL_keywords,
-        "//","/* ","*/",
+        "//","///","/* ","*/",
         HL_HIGHLIGHT_STRINGS | HL_HIGHLIGHT_NUMBERS
     },
     {
         PY_HL_extensions,
         PY_HL_keywords,
-        "# ","\"\"\"","\"\"\"",
+        "# ","## ","\"\"\"","\"\"\"",
         HL_HIGHLIGHT_STRINGS | HL_HIGHLIGHT_NUMBERS
     }
 };
@@ -415,6 +416,7 @@ void editorUpdateSyntax(erow *row) {
     char *p;
     char **keywords = E.syntax->keywords;
     char *scs = E.syntax->singleline_comment_start;
+	char *sds = E.syntax->singleline_doc_comment_start;
     char *mcs = E.syntax->multiline_comment_start;
     char *mce = E.syntax->multiline_comment_end;
 
@@ -436,7 +438,8 @@ void editorUpdateSyntax(erow *row) {
 
     while(*p) {
         /* Handle // comments. */
-        if (prev_sep && *p == scs[0] && *(p+1) == scs[1] && !in_string) {
+        if (prev_sep && *p == scs[0] && *(p+1) == scs[1] && !in_string ||
+				prev_sep && *p == sds[0] && *(p+1) == sds[1] && !in_string) {
             /* From here to end is a comment */
             memset(row->hl+i,HL_COMMENT,row->size-i);
             return;

--- a/kilo.c
+++ b/kilo.c
@@ -237,7 +237,6 @@ void editorAtExit(void) {
         editorFreeRow(&E.row[i]);
     }
     free(E.filename);
-    free(E.statusmsg);
     free(E.row);
 }
 
@@ -1180,6 +1179,25 @@ void editorMoveCursor(int key) {
             }
         }
         break;
+    case PAGE_UP:
+    case PAGE_DOWN:
+        if (key == PAGE_UP && E.cy != 0)
+            E.cy = 0;
+        else if (key == PAGE_DOWN && E.cy != E.screenrows-1)
+            E.cy = E.screenrows-1;
+        {
+        int times = E.screenrows-1;/* So we can see the top and bottom lines still */
+        while(times--)
+            editorMoveCursor(key == PAGE_UP ? ARROW_UP:
+                                            ARROW_DOWN);
+        }
+        break;
+    case HOME_KEY:
+	E.cx = 0;
+	break;
+    case END_KEY:
+	E.cx = E.row[filerow-1].size;
+	break;
     }
     /* Fix cx if the current line has not enough chars. */
     filerow = E.rowoff+E.cy;
@@ -1238,18 +1256,8 @@ void editorProcessKeypress(int fd) {
 		break;
     case PAGE_UP:
     case PAGE_DOWN:
-        if (c == PAGE_UP && E.cy != 0)
-            E.cy = 0;
-        else if (c == PAGE_DOWN && E.cy != E.screenrows-1)
-            E.cy = E.screenrows-1;
-        {
-        int times = E.screenrows;
-        while(times--)
-            editorMoveCursor(c == PAGE_UP ? ARROW_UP:
-                                            ARROW_DOWN);
-        }
-        break;
-
+    case HOME_KEY:
+    case END_KEY:
     case ARROW_UP:
     case ARROW_DOWN:
     case ARROW_LEFT:

--- a/kilo.c
+++ b/kilo.c
@@ -65,6 +65,7 @@
 #define HL_HIGHLIGHT_STRINGS (1<<0)
 #define HL_HIGHLIGHT_NUMBERS (1<<1)
 
+/* // incase min and max needed in the future.
 #define min(a,b) \
 	({ __typeof__ (a) _a = (a); \
 	 __typeof__ (b) _b = (b); \
@@ -73,7 +74,7 @@
 	({ __typeof__ (a) _a = (a); \
 	 __typeof__ (b) _b = (b); \
 	 _a > _b ? _a : _b; })
-
+*/
 
 /* Defining a couple functions here to prevent compiler warnings */
 time_t  time(void*);

--- a/kilo.c
+++ b/kilo.c
@@ -159,7 +159,7 @@ void editorSetStatusMessage(const char *fmt, ...);
  * There is no support to highlight patterns currently. */
 
 /* C / C++ */
-char *C_HL_extensions[] = {".c",".cpp",NULL};
+char *C_HL_extensions[] = {".c",".cpp",".h",".hpp",NULL};
 char *C_HL_keywords[] = {
         /* A few C / C++ keywords */
         "switch","if","while","for","break","continue","return","else",

--- a/kilo.c
+++ b/kilo.c
@@ -72,7 +72,7 @@ struct editorSyntax {
     char **filematch;
     char **keywords;
     char singleline_comment_start[2];
-	char singleline_doc_comment_start[4];
+    char singleline_doc_comment_start[4];
     char multiline_comment_start[4];
     char multiline_comment_end[4];
     int flags;
@@ -168,9 +168,9 @@ char *C_HL_keywords[] = {
         /* A few C / C++ keywords */
         "auto","switch","if","while","for","break","continue","return","else",
         "struct","union","typedef","static","enum","class",
-	/* C preprocessor directives */
-	"#define|","#endif|","#error|","#ifdef|","#ifndef|","#if|",
-	"#include|","#undef|",
+    /* C preprocessor directives */
+    "#define|","#endif|","#error|","#ifdef|","#ifndef|","#if|",
+    "#include|","#undef|",
         /* C types */
         "int|","long|","double|","float|","char|","unsigned|","signed|",
         "void|",NULL
@@ -179,8 +179,8 @@ char *C_HL_keywords[] = {
 /* Python */
 char *PY_HL_extensions[] = {".py",".python",NULL};
 char *PY_HL_keywords[] = {
-	/* Normal Python reserved words "self" is not exactly a keyword,*/
-	/* but I prefer it. */
+    /* Normal Python reserved words "self" is not exactly a keyword,*/
+    /* but I prefer it. */
         "False","None","True","and","as","assert","break","class","continue",
         "def","del","elif","else","except","finally","for","from","global",
         "if","import","in","is","lambda","nonlocal","not","or","pass","raise",
@@ -416,7 +416,7 @@ void editorUpdateSyntax(erow *row) {
     char *p;
     char **keywords = E.syntax->keywords;
     char *scs = E.syntax->singleline_comment_start;
-	char *sds = E.syntax->singleline_doc_comment_start;
+    char *sds = E.syntax->singleline_doc_comment_start;
     char *mcs = E.syntax->multiline_comment_start;
     char *mce = E.syntax->multiline_comment_end;
 
@@ -439,7 +439,7 @@ void editorUpdateSyntax(erow *row) {
     while(*p) {
         /* Handle // comments. */
         if (prev_sep && *p == scs[0] && *(p+1) == scs[1] && !in_string ||
-				prev_sep && *p == sds[0] && *(p+1) == sds[1] && !in_string) {
+                prev_sep && *p == sds[0] && *(p+1) == sds[1] && !in_string) {
             /* From here to end is a comment */
             memset(row->hl+i,HL_COMMENT,row->size-i);
             return;
@@ -507,9 +507,9 @@ void editorUpdateSyntax(erow *row) {
             continue;
         }
 
-	if (is_separator(*p)) {
+    if (is_separator(*p)) {
             row->hl[i] = HL_KEYWORD1;
-	}
+    }
         /* Handle keywords and lib calls */
         if (prev_sep) {
             int j;
@@ -1196,11 +1196,11 @@ void editorMoveCursor(int key) {
         }
         break;
     case HOME_KEY:
-	E.cx = 0;
-	break;
+    E.cx = 0;
+    break;
     case END_KEY:
-	E.cx = E.row[filerow-1].size;
-	break;
+    E.cx = E.row[filerow-1].size;
+    break;
     }
     /* Fix cx if the current line has not enough chars. */
     filerow = E.rowoff+E.cy;
@@ -1254,9 +1254,9 @@ void editorProcessKeypress(int fd) {
         editorDelChar();
         break;
     case DEL_KEY:
-		editorMoveCursor(ARROW_RIGHT);
-		editorDelChar();
-		break;
+        editorMoveCursor(ARROW_RIGHT);
+        editorDelChar();
+        break;
     case PAGE_UP:
     case PAGE_DOWN:
     case HOME_KEY:

--- a/kilo.c
+++ b/kilo.c
@@ -65,6 +65,9 @@
 #define HL_HIGHLIGHT_STRINGS (1<<0)
 #define HL_HIGHLIGHT_NUMBERS (1<<1)
 
+/* Defining a couple functions here to prevent compiler warnings */
+time_t  time(void*);
+
 struct editorSyntax {
     char **filematch;
     char **keywords;
@@ -163,7 +166,7 @@ char *C_HL_extensions[] = {".c",".cpp",".h",".hpp",NULL};
 char *C_HL_keywords[] = {
         /* A few C / C++ keywords */
         "switch","if","while","for","break","continue","return","else",
-        "struct","union","typedef","static","enum","class",
+        "struct","union","typedef","static","enum","class","#include","#define",
         /* C types */
         "int|","long|","double|","float|","char|","unsigned|","signed|",
         "void|",NULL
@@ -198,6 +201,7 @@ void disableRawMode(int fd) {
 /* Called at exit to avoid remaining in raw mode. */
 void editorAtExit(void) {
     disableRawMode(STDIN_FILENO);
+    printf("\033[2J\033[1;1H"); /* Clears the entire screen */
 }
 
 /* Raw mode: 1960 magic shit. */
@@ -209,7 +213,7 @@ int enableRawMode(int fd) {
     atexit(editorAtExit);
     if (tcgetattr(fd,&orig_termios) == -1) goto fatal;
 
-    raw = orig_termios;  /* modify the original mode */
+    raw = orig_termios; /* modify the original mode */
     /* input modes: no break, no CR to NL, no parity check, no strip char,
      * no start/stop output control. */
     raw.c_iflag &= ~(BRKINT | ICRNL | INPCK | ISTRIP | IXON);

--- a/kilo.c
+++ b/kilo.c
@@ -1192,9 +1192,12 @@ void editorProcessKeypress(int fd) {
         break;
     case BACKSPACE:     /* Backspace */
     case CTRL_H:        /* Ctrl-h */
-    case DEL_KEY:
         editorDelChar();
         break;
+    case DEL_KEY:
+		editorMoveCursor(ARROW_RIGHT);
+		editorDelChar();
+		break;
     case PAGE_UP:
     case PAGE_DOWN:
         if (c == PAGE_UP && E.cy != 0)

--- a/kilo.c
+++ b/kilo.c
@@ -37,19 +37,18 @@
 #define _DEFAULT_SOURCE
 #define _GNU_SOURCE
 
-#include <termios.h>
-#include <stdlib.h>
-#include <stdio.h>
-#include <errno.h>
-#include <string.h>
-#include <stdlib.h>
 #include <ctype.h>
-#include <sys/types.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 #include <sys/ioctl.h>
 #include <sys/time.h>
+#include <sys/types.h>
+#include <termios.h>
 #include <unistd.h>
-#include <stdarg.h>
-#include <fcntl.h>
 
 /* Syntax highlight types */
 #define HL_NORMAL 0
@@ -180,7 +179,7 @@ char *C_HL_keywords[] = {
         "auto","switch","if","while","for","break","continue","return","else",
         "struct","union","typedef","static","enum","class",
         /* C preprocessor directives and types*/
-        "#define|","#endif|","#error|","#ifdef|","#ifndef|","#if|", "#include|",
+        "#define","#endif","#error","#ifdef","#ifndef","#if", "#include",
         "#undef|","int|","long|","double|","float|","char|", "unsigned|",
         "signed|","void|",NULL
 };
@@ -1191,18 +1190,6 @@ void editorMoveCursor(int key) {
             }
         }
         break;
-    case PAGE_UP:
-    case PAGE_DOWN:
-        if (key == PAGE_UP && E.cy != 0)
-            E.cy = 0;
-        else if (key == PAGE_DOWN && E.cy != E.screenrows-1)
-            E.cy = E.screenrows-1;
-        /* So we can see the top and bottom lines still */
-        int times = E.screenrows-1;
-        while(times--)
-            editorMoveCursor(key == PAGE_UP ? ARROW_UP:
-                                            ARROW_DOWN);
-        break;
     case HOME_KEY:
         E.cx = 0;
         break;
@@ -1268,6 +1255,16 @@ void editorProcessKeypress(int fd) {
         break;
     case PAGE_UP:
     case PAGE_DOWN:
+        if (c == PAGE_UP && E.cy != 0)
+            E.cy = 0;
+        else if (c == PAGE_DOWN && E.cy != E.screenrows-1)
+            E.cy = E.screenrows-1;
+        /* So we can see the top and bottom lines still */
+        int times = E.screenrows-1;
+        while(times--)
+            editorMoveCursor(c == PAGE_UP ? ARROW_UP:
+                                            ARROW_DOWN);
+        break;
     case HOME_KEY:
     case END_KEY:
     case ARROW_UP:


### PR DESCRIPTION
Added syntax highlighting for Python and added HOME and END key movements.  Stopped comments from being comment-highlighted while they are in strings.