### PR TITLE
Remove unnecessary initialization code for editor

### DIFF
--- a/kilo.c
+++ b/kilo.c
@@ -1234,15 +1234,6 @@ int editorFileWasModified(void) {
 }
 
 void initEditor(void) {
-    E.cx = 0;
-    E.cy = 0;
-    E.rowoff = 0;
-    E.coloff = 0;
-    E.numrows = 0;
-    E.row = NULL;
-    E.dirty = 0;
-    E.filename = NULL;
-    E.syntax = NULL;
     if (getWindowSize(STDIN_FILENO,STDOUT_FILENO,
                       &E.screenrows,&E.screencols) == -1)
     {


### PR DESCRIPTION
As per c99 section 6.7.8 global variables are 'zeroed', making
code redundant.