### PR TITLE
Use _POSIX_C_SOURCE, drop _BSD_SOURCE, _GNU_SOURCE (#5, #12)

### DIFF
--- a/kilo.c
+++ b/kilo.c
@@ -34,8 +34,7 @@
 
 #define KILO_VERSION "0.0.1"
 
-#define _BSD_SOURCE
-#define _GNU_SOURCE
+#define _POSIX_C_SOURCE 200809L
 
 #include <termios.h>
 #include <stdlib.h>
@@ -44,6 +43,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <ctype.h>
+#include <time.h>
 #include <sys/types.h>
 #include <sys/ioctl.h>
 #include <sys/time.h>


### PR DESCRIPTION
The only need for `_BSD_SOURCE` is a single use of the trivial, but non-standard, `strdup()`. The only need for `_GNU_SOURCE` is for `getline()`. This function was standardized by POSIX 10 years ago, so you only need to ask for it with `_POSIX_C_SOURCE`.

Also added time.h which is only included by luck via the removed feature test macros.

This is better than PR #5 because `_DEFAULT_SOURCE` isn't needed at all.
