### PR TITLE
Fix out of bounds read of render buffer

### DIFF
--- a/kilo.c
+++ b/kilo.c
@@ -469,8 +469,12 @@ void editorUpdateSyntax(erow *row) {
             int j;
             for (j = 0; keywords[j]; j++) {
                 int klen = strlen(keywords[j]);
+                int rlen = row->rsize - (p - row->render);
                 int kw2 = keywords[j][klen-1] == '|';
                 if (kw2) klen--;
+
+                if (rlen < klen)
+                    continue;
 
                 if (!memcmp(p,keywords[j],klen) &&
                     is_separator(*(p+klen)))


### PR DESCRIPTION
When characters in a render buffer are compared
to the strings in the keywords array this is
possible that p + klen points out of the buffer
and memcmp results to out-of-bounds access.

To see that this is true just recompile kilo
using GCC with the option -fsanitize=address
and open any file using the fresh build of kilo.
Address Sanitizer points to the problem
immediately.