### PR TITLE
include right header file

### DIFF
--- a/kilo.c
+++ b/kilo.c
@@ -46,7 +46,7 @@
 #include <ctype.h>
 #include <sys/types.h>
 #include <sys/ioctl.h>
-#include <sys/time.h>
+#include <time.h>
 #include <unistd.h>
 #include <stdarg.h>
 #include <fcntl.h>


### PR DESCRIPTION
There is a warning:
`kilo.c:953:19: warning: implicit declaration of function ‘time’; did you mean ‘tee’? [-Wimplicit-function-declaration]`