### PR TITLE
Fixing the ‘UINT32_MAX’ undeclared problem

### DIFF
--- a/kilo.c
+++ b/kilo.c
@@ -41,6 +41,7 @@
 #include <termios.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include <stdint.h>
 #include <errno.h>
 #include <string.h>
 #include <ctype.h>


### PR DESCRIPTION
This commit fix the ‘UINT32_MAX’ undeclared problem in Linux
I mentioned in the issue #67 by including <stdint.h>