### PR TITLE
Set tab width to 8

### DIFF
--- a/kilo.c
+++ b/kilo.c
@@ -575,7 +575,7 @@ void editorUpdateRow(erow *row) {
     for (j = 0; j < row->size; j++) {
         if (row->chars[j] == TAB) {
             row->render[idx++] = ' ';
-            while((idx+1) % 8 != 0) row->render[idx++] = ' ';
+            while(idx % 8 != 0) row->render[idx++] = ' ';
         } else {
             row->render[idx++] = row->chars[j];
         }
@@ -981,7 +981,7 @@ void editorRefreshScreen(void) {
      * at which the cursor is displayed may be different compared to 'E.cx'
      * because of TABs. */
     int j;
-    int cx = 1;
+    int cx = 0;
     int filerow = E.rowoff+E.cy;
     erow *row = (filerow >= E.numrows) ? NULL : &E.row[filerow];
     if (row) {
@@ -990,7 +990,7 @@ void editorRefreshScreen(void) {
             cx++;
         }
     }
-    snprintf(buf,sizeof(buf),"\x1b[%d;%dH",E.cy+1,cx);
+    snprintf(buf,sizeof(buf),"\x1b[%d;%dH",E.cy+1,cx+1);
     abAppend(&ab,buf,strlen(buf));
     abAppend(&ab,"\x1b[?25h",6); /* Show cursor. */
     write(STDOUT_FILENO,ab.b,ab.len);


### PR DESCRIPTION
It looks tab stops at `n*8` column position (1 origin).
So if tab is put at the beginning of a line, the line has 7 spaces, not 8.
