### PR TITLE
fix a typo when deleting a row

### DIFF
--- a/kilo.c
+++ b/kilo.c
@@ -625,7 +625,7 @@ void editorDelRow(int at) {
     row = E.row+at;
     editorFreeRow(row);
     memmove(E.row+at,E.row+at+1,sizeof(E.row[0])*(E.numrows-at-1));
-    for (int j = at; j < E.numrows-1; j++) E.row[j].idx++;
+    for (int j = at; j < E.numrows-1; j++) E.row[j].idx--;
     E.numrows--;
     E.dirty++;
 }


### PR DESCRIPTION
I believe `struct erow` requires the following invariant:

```
for (int i = 0; i < E.numrows; ++i)
  assert(E.row[i].idx == i);
```

This is important because `erow.idx` is used to index into `E.row` in various places. Incrementing `idx` can cause out of bounds access and memory corruption.