### PR TITLE
Fix memset issue in highlighting

### DIFF
--- a/kilo.c
+++ b/kilo.c
@@ -412,7 +412,7 @@ void editorUpdateSyntax(erow *row) {
         /* Handle // comments. */
         if (prev_sep && *p == scs[0] && *(p+1) == scs[1]) {
             /* From here to end is a comment */
-            memset(row->hl+i,HL_COMMENT,row->size-i);
+            memset(row->hl+i,HL_COMMENT,row->rsize-i);
             return;
         }
 


### PR DESCRIPTION
The previous memset used an incorrect variable causing various issues with single line comments.