### PR TITLE
Add alt-screen support

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -1,0 +1,14 @@
+# This is the list of the Kilo text editor's contributors. This file
+# is styled after the "humans.txt" style for websites.
+#
+# This does not necessarily list everyone who has contributed code.
+# To see the full list of contributors, see the revision history in
+# source control. For the list of active maintainers, see
+# MAINTAINERS.txt
+
+	Maintainer: Salvatore Sanfilippo
+	Contact: <antirez at gmail dot com>
+
+	Alt-screen contributor: jam555
+	Contact: <3349478+jam555@users.noreply.github.com>
+	From: USA

--- a/MAINTAINERS.txt
+++ b/MAINTAINERS.txt
@@ -1,0 +1,7 @@
+# This is the list of the Kilo text editor's maintainers.
+#
+# This does not necessarily list everyone who has contributed code.
+# To see the full list of contributors, see the revision history in
+# source control.
+
+Salvatore Sanfilippo

--- a/TODO
+++ b/TODO
@@ -6,5 +6,4 @@ IMPORTANT
 MAYBE
 ===
 
-* Send alternate screen sequences if TERM=xterm: "\033[?1049h" and "\033[?1049l"
 * Improve internals to be more understandable.

--- a/kilo.c
+++ b/kilo.c
@@ -1317,14 +1317,18 @@ void initEditor(void) {
     E.syntax = NULL;
     if( !E.altscr && !E.no_altscr )
     {
-        /* Activate alternate screen. To disable, use 'l' instead of 'h'. */
-        const char altscren[] = "\x1b[?1049h\n";
-        const int altscren_len = sizeof( altscren );
-        if ( write(STDOUT_FILENO, altscren, altscren_len) != altscren_len) {
-            perror("Unable to select the alternate screen display buffer");
-            exit(1);
+        char *termstr = getenv( "TERM" );
+        if( termstr && strstr( termstr, "xterm" ) )
+        {
+            /* Activate alternate screen. To disable, use 'l' instead of 'h'. */
+            const char altscren[] = "\x1b[?1049h\n";
+            const int altscren_len = sizeof( altscren );
+            if ( write(STDOUT_FILENO, altscren, altscren_len) != altscren_len) {
+                perror("Unable to select the alternate screen display buffer");
+                exit(1);
+            }
+            E.altscr = 1;
         }
-        E.altscr = 1;
     }
     updateWindowSize();
     signal(SIGWINCH, handleSigWinCh);

--- a/kilo.c
+++ b/kilo.c
@@ -94,6 +94,8 @@ typedef struct hlcolor {
 } hlcolor;
 
 struct editorConfig {
+    int no_altscr;  /* Forbid usage of the alternate-screen. */
+
     int cx,cy;  /* Cursor x and y position in characters */
     int rowoff;     /* Offset of row displayed. */
     int coloff;     /* Offset of column displayed. */
@@ -1309,7 +1311,7 @@ void initEditor(void) {
     E.dirty = 0;
     E.filename = NULL;
     E.syntax = NULL;
-    if( !E.altscr )
+    if( !E.altscr && !E.no_altscr )
     {
         /* Activate alternate screen. To disable, use 'l' instead of 'h'. */
         const char altscren[] = "\x1b[?1049h\n";
@@ -1325,9 +1327,23 @@ void initEditor(void) {
 }
 
 int main(int argc, char **argv) {
-    if (argc != 2) {
-        fprintf(stderr,"Usage: kilo <filename>\n");
+    const char noaltscr_opt[] = "--no-alt-screen";
+    if (argc < 2 || argc > 3) {
+        fprintf(stderr,"Usage: kilo <filename> [%s]\n",noaltscr_opt);
         exit(1);
+    }
+
+    if(argc == 3) {
+        /* Surpress usage of the alternate screen: useful if you */
+        /*  want to keep info displayed on exit. */
+        if( strcmp( noaltscr_opt, argv[2] ) != 0 ) {
+            perror("Unfamiliar option:");
+            fprintf(stderr,"  %s",argv[2]);
+            exit(1);
+        }
+        E.no_altscr = 1;
+    } else {
+        E.no_altscr = 0;
     }
 
     initEditor();

--- a/kilo.c
+++ b/kilo.c
@@ -101,6 +101,7 @@ struct editorConfig {
     int screencols; /* Number of cols that we can show */
     int numrows;    /* Number of rows */
     int rawmode;    /* Is terminal raw mode enabled? */
+    int altscr;     /* Is terminal alternate-screen selected? */
     erow *row;      /* Rows */
     int dirty;      /* File modified but not saved. */
     char *filename; /* Currently open filename */
@@ -212,6 +213,26 @@ void disableRawMode(int fd) {
 /* Called at exit to avoid remaining in raw mode. */
 void editorAtExit(void) {
     disableRawMode(STDIN_FILENO);
+
+    /* Disable alternate screen. */
+    if( E.altscr )
+    {
+        /* "?47l" ~1978 VT100 DECSET magic. "?1049l" is similar xterm magic */
+		/*  from... some indeterminate time, possibly even before X Windows */
+		/*  existed. */
+            /* To instead enable, use 'h' instead of 'l': note that */
+            /*  initEditor() does the enabling already. */
+        const char altscren[] = "\x1b[?47l";
+        const int altscren_len = sizeof( altscren );
+        if (write(STDOUT_FILENO, "\x1b[?47l", altscren_len) != altscren_len) {
+            perror("Unable to deselect the alternate screen display buffer");
+            perror("please type" );
+			perror("  echo -e \"\\e[?47l\"");
+            perror("and then hit your enter key" );
+            exit(1);
+        }
+        E.altscr = 0;
+    }
 }
 
 /* Raw mode: 1960 magic shit. */
@@ -1279,11 +1300,26 @@ void initEditor(void) {
     E.cy = 0;
     E.rowoff = 0;
     E.coloff = 0;
+    E.screenrows = 0;
+    E.screencols = 0;
     E.numrows = 0;
+    E.rawmode = 0;
+    E.altscr = 0;
     E.row = NULL;
     E.dirty = 0;
     E.filename = NULL;
     E.syntax = NULL;
+    if( !E.altscr )
+    {
+        /* Activate alternate screen. To disable, use 'l' instead of 'h'. */
+        const char altscren[] = "\x1b[?47h\n";
+        const int altscren_len = sizeof( altscren );
+        if ( write(STDOUT_FILENO, altscren, altscren_len) != altscren_len) {
+            perror("Unable to select the alternate screen display buffer");
+            exit(1);
+        }
+        E.altscr = 1;
+    }
     updateWindowSize();
     signal(SIGWINCH, handleSigWinCh);
 }

--- a/kilo.c
+++ b/kilo.c
@@ -217,8 +217,7 @@ void editorAtExit(void) {
     disableRawMode(STDIN_FILENO);
 
     /* Disable alternate screen. */
-    if( E.altscr )
-    {
+    if( E.altscr ) {
         /* "?47l" ~1978 VT100 DECSET magic. "?1049l" is similar xterm magic */
 		/*  from... some indeterminate time, possibly even before X Windows */
 		/*  existed. */
@@ -234,6 +233,11 @@ void editorAtExit(void) {
             exit(1);
         }
         E.altscr = 0;
+    } else if( E.no_altscr ) {
+        /* If we aren't using the alternate-screen, move the cursor to the */
+        /*  end of the screen and force a line-advance instead, to prepare */
+        /*  for the return to the CLI. */
+        printf("\x1b[%d;%dH\n\n",E.screenrows+1,E.screencols+1);
     }
 }
 

--- a/kilo.c
+++ b/kilo.c
@@ -222,12 +222,12 @@ void editorAtExit(void) {
 		/*  existed. */
             /* To instead enable, use 'h' instead of 'l': note that */
             /*  initEditor() does the enabling already. */
-        const char altscren[] = "\x1b[?47l";
+        const char altscren[] = "\x1b[?1049l";
         const int altscren_len = sizeof( altscren );
-        if (write(STDOUT_FILENO, "\x1b[?47l", altscren_len) != altscren_len) {
+        if (write(STDOUT_FILENO, altscren, altscren_len) != altscren_len) {
             perror("Unable to deselect the alternate screen display buffer");
             perror("please type" );
-			perror("  echo -e \"\\e[?47l\"");
+			perror("  echo -e \"\\e[?1049l\"");
             perror("and then hit your enter key" );
             exit(1);
         }
@@ -1312,7 +1312,7 @@ void initEditor(void) {
     if( !E.altscr )
     {
         /* Activate alternate screen. To disable, use 'l' instead of 'h'. */
-        const char altscren[] = "\x1b[?47h\n";
+        const char altscren[] = "\x1b[?1049h\n";
         const int altscren_len = sizeof( altscren );
         if ( write(STDOUT_FILENO, altscren, altscren_len) != altscren_len) {
             perror("Unable to select the alternate screen display buffer");


### PR DESCRIPTION
closes antirez/kilo#48

Uses the xterm-style "?1049l" & "?1049h" escape codes to use the alternate screen buffer of some ANSI terminal emulators to avoid overwriting the data displayed on the terminal before Kilo was started. Includes a command-line argument to suppress this same behavior. Ensures that if the alt-screen WAS NOT used, then the cursor is placed on a new line directly BELOW the remaining displayed lines of Kilo, so that new commands can be typed without altering the visibility of what Kilo had previously displayed.

So: implements alt-screen, provides a command-line override, and ensures that things look nice if the override is used.

I've also added maintainer & contributor files, but I don't know if the project has a rule on those?