### PR TITLE
Fix string truncation warning in editorSyntax struct

### DIFF
--- a/kilo.c
+++ b/kilo.c
@@ -71,9 +71,9 @@
 struct editorSyntax {
     char **filematch;
     char **keywords;
-    char singleline_comment_start[2];
-    char multiline_comment_start[3];
-    char multiline_comment_end[3];
+    char singleline_comment_start[3];
+    char multiline_comment_start[4];
+    char multiline_comment_end[4];
     int flags;
 };
 


### PR DESCRIPTION
Increase array sizes for comment delimiter fields to include space for the null terminator, fixing -Wunterminated-string-initialization warning with modern compilers.
