### PR TITLE
Fixing unterminated string literal

### DIFF
--- a/kilo.c
+++ b/kilo.c
@@ -71,7 +71,7 @@
 struct editorSyntax {
     char **filematch;
     char **keywords;
-    char singleline_comment_start[2];
+    char singleline_comment_start[3];
     char multiline_comment_start[3];
     char multiline_comment_end[3];
     int flags;


### PR DESCRIPTION
The single line comment start wasn't accounting for the \0 null terminator.